### PR TITLE
Add a starting package-lock.json file to allow builds to succeed

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "helloworld-node-demo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "helloworld-node-demo",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}


### PR DESCRIPTION
After running `docker init` on the node sample, the build will fail because the lock file is missing. This fixes that!