### PR TITLE
fix(java): typo not passing tests

### DIFF
--- a/java/src/main/java/com/example/restservice/greeting/GreetingController.java
+++ b/java/src/main/java/com/example/restservice/greeting/GreetingController.java
@@ -13,7 +13,7 @@ public class GreetingController {
 	private final AtomicLong counter = new AtomicLong();
 
 	@GetMapping("/greeting")
-	public Greeting greeting(@RequestParam(value = "name", defaultValue = "Docker!") String name) {
+	public Greeting greeting(@RequestParam(value = "name", defaultValue = "Docker") String name) {
 		return new Greeting(counter.incrementAndGet(), String.format(template, name));
 	}
 }


### PR DESCRIPTION
Fix a typo in Java example.
It wasn't indicated in README, so I don't know if this was accidental or for demo purpose?